### PR TITLE
Development

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,26 +33,41 @@ By separating the processes, the server GUI can be fully featured, initializing 
 - (future) Behavioral unit tests: Test whether code changes break previous layout behavior by keeping a reference.gds and creating a test.gds, then send them to klayout's visual diff tool.
 
 ## Installation
-#### Server from salt package manager
+#### From PyPI (Recommended)
+As of version 0.1.5, installing the python package triggers a script to also install in klayout's system. All you need to do is
+```sh
+pip install lyipc
+```
+
+#### From github (Recommended for developers)
+First, clone the project in a directory of your choice
+```sh
+git clone git@github.com:atait/klayout-ipc.git
+```
+Install the package with regular pip
+```sh
+pip install klayout-ipc/klayout_dot_config/python
+```
+For development mode, use pip's `-e` flag.
+
+As of version 0.1.5, this will also install it into klayout, so you're done.
+
+
+#### From klayout salt package manager
 In klayout.app, go to "Tools>Manage Packages". Go to "Install New Packages" and find "klayout_ipc". Double-click it, and press "Apply".
 
-#### Server from source
-1. In a directory of choice, `git clone git@github.com:atait/klayout-ipc.git`
-2. "Install" in .klayout system files
-    - (OSX, Linux) `ln -s ~/your/path/to/klayout-ipc/klayout_dot_config ~/.klayout/salt/klayout_ipc`
-    - (Windows) right click the folder and create an alias to C:\\Username\KLayout\salt [path correct?]
-
-or
-
-2. Show klayout where it is
-    - `export KLAYOUT_PATH="~/your/path/to/klayout-ipc/klayout_dot_config"`
-
-#### Client
+*You still have to install the client module in your external-to-klayout system python*
 The lyipc package is visible within klayout's interpreter namespace, but it is not on the system PYTHONPATH. In order for any python-based client to use it, lyipc must be installed with
 ```sh
 pip install ~/.klayout/salt/klayout_ipc/python
 ```
-(will be different on windows). For development mode, use pip's `-e` flag.
+or, on Windows
+```sh
+pip install %HOMEDRIVE%%HOMEPATH%/KLayout/salt/klayout_ipc/python
+```
+because... Windows.
+
+
 
 #### Application setup
 When an open file changes on disk, by default, KLayout asks whether to reload it. These prompts persist when reload is triggered by a communicating process instead of a human. Disable checks by going to klayout.app's preferences > Application > General, and uncheck the box for "Check for file updates."

--- a/klayout_dot_config/doc/README.html
+++ b/klayout_dot_config/doc/README.html
@@ -1095,29 +1095,29 @@ body .markdown-body
 <li>(future) Behavioral unit tests: Test whether code changes break previous layout behavior by keeping a reference.gds and creating a test.gds, then send them to klayout&rsquo;s visual diff tool.</li>
 </ul>
 <h2 id="installation">Installation<a class="headerlink" href="#installation" title="Permanent link"></a></h2>
-<h4 id="server-from-salt-package-manager">Server from salt package manager<a class="headerlink" href="#server-from-salt-package-manager" title="Permanent link"></a></h4>
+<h4 id="from-pypi-recommended">From PyPI (Recommended)<a class="headerlink" href="#from-pypi-recommended" title="Permanent link"></a></h4>
+<p>As of version 0.1.5, installing the python package triggers a script to also install in klayout&rsquo;s system. All you need to do is
+<div class="codehilite"><pre>pip install lyipc
+</pre></div></p>
+<h4 id="from-github-recommended-for-developers">From github (Recommended for developers)<a class="headerlink" href="#from-github-recommended-for-developers" title="Permanent link"></a></h4>
+<p>First, clone the project in a directory of your choice
+<div class="codehilite"><pre>git clone git@github.com:atait/klayout-ipc.git
+</pre></div>
+Install the package with regular pip
+<div class="codehilite"><pre>pip install klayout-ipc/klayout_dot_config/python
+</pre></div>
+For development mode, use pip&rsquo;s <code>-e</code> flag.</p>
+<p>As of version 0.1.5, this will also install it into klayout, so you&rsquo;re done.</p>
+<h4 id="from-klayout-salt-package-manager">From klayout salt package manager<a class="headerlink" href="#from-klayout-salt-package-manager" title="Permanent link"></a></h4>
 <p>In klayout.app, go to &ldquo;Tools&gt;Manage Packages&rdquo;. Go to &ldquo;Install New Packages&rdquo; and find &ldquo;klayout_ipc&rdquo;. Double-click it, and press &ldquo;Apply&rdquo;.</p>
-<h4 id="server-from-source">Server from source<a class="headerlink" href="#server-from-source" title="Permanent link"></a></h4>
-<ol>
-<li>In a directory of choice, <code>git clone git@github.com:atait/klayout-ipc.git</code></li>
-<li>&ldquo;Install&rdquo; in .klayout system files<ul>
-<li>(OSX, Linux) <code>ln -s ~/your/path/to/klayout-ipc/klayout_dot_config ~/.klayout/salt/klayout_ipc</code></li>
-<li>(Windows) right click the folder and create an alias to C:\Username\KLayout\salt [path correct?]</li>
-</ul>
-</li>
-</ol>
-<p>or</p>
-<ol>
-<li>Show klayout where it is<ul>
-<li><code>export KLAYOUT_PATH="~/your/path/to/klayout-ipc/klayout_dot_config"</code></li>
-</ul>
-</li>
-</ol>
-<h4 id="client">Client<a class="headerlink" href="#client" title="Permanent link"></a></h4>
-<p>The lyipc package is visible within klayout&rsquo;s interpreter namespace, but it is not on the system PYTHONPATH. In order for any python-based client to use it, lyipc must be installed with
+<p><em>You still have to install the client module in your external-to-klayout system python</em>
+The lyipc package is visible within klayout&rsquo;s interpreter namespace, but it is not on the system PYTHONPATH. In order for any python-based client to use it, lyipc must be installed with
 <div class="codehilite"><pre>pip install ~/.klayout/salt/klayout_ipc/python
 </pre></div>
-(will be different on windows). For development mode, use pip&rsquo;s <code>-e</code> flag.</p>
+or, on Windows
+<div class="codehilite"><pre>pip install %HOMEDRIVE%%HOMEPATH%/KLayout/salt/klayout_ipc/python
+</pre></div>
+because&hellip; Windows.</p>
 <h4 id="application-setup">Application setup<a class="headerlink" href="#application-setup" title="Permanent link"></a></h4>
 <p>When an open file changes on disk, by default, KLayout asks whether to reload it. These prompts persist when reload is triggered by a communicating process instead of a human. Disable checks by going to klayout.app&rsquo;s preferences &gt; Application &gt; General, and uncheck the box for &ldquo;Check for file updates.&rdquo;</p>
 <h2 id="usage">Usage<a class="headerlink" href="#usage" title="Permanent link"></a></h2>

--- a/klayout_dot_config/python/README.rst
+++ b/klayout_dot_config/python/README.rst
@@ -1,15 +1,17 @@
 KLayout inter-process communication (lyipc)
 ===========================================
 
-This is brief documentation for the client side of the package. To see the full project and documentation, go to https://github.com/atait/klayout-ipc.
+This is brief documentation. To see the full project and documentation, go to https://github.com/atait/klayout-ipc.
 
 Setup
 ***************************************
-The lyipc package is visible within klayout's interpreter namespace, but it is not on the system python path. In order for an external python-based program to use it, lyipc must be installed on the python path.
+If you are a user, do::
 
-This is done in the klayout_dot_config/python directory with::
+    pip install lyipc
 
-    python setup.py install
+If you are installing from source and/or developing, you are probably not reading this on PyPI but rather on github. Anyways, the best way is to install using the local setup.py formulation.::
+
+    pip install -e klayout-ipc/klayout_dot_config/python
 
 Usage
 *****

--- a/klayout_dot_config/python/setup.py
+++ b/klayout_dot_config/python/setup.py
@@ -1,8 +1,87 @@
 from setuptools import setup
+from setuptools.command.install import install
+
+def is_windows():
+    from sys import platform
+    if platform == "linux" or platform == "linux2":
+        return False
+    elif platform == "darwin":
+        return False
+    elif platform == "win32":
+        return True
+    else:
+        raise ValueError('Unrecognized operating system: {}'.format(platform))
+
+
+import os
+def link_to_salt():
+    user_home = os.path.expanduser('~')
+    if is_windows():
+        klayout_config_dir = os.path.join(user_home, 'KLayout')
+    else:
+        klayout_config_dir = os.path.join(user_home, '.klayout')
+    if not os.path.exists(klayout_config_dir):
+        raise FileNotFoundError('The KLayout config directory was not found. KLayout might not be installed.')
+    salt_dir = os.path.join(klayout_config_dir, 'salt')
+    if not os.path.exists(salt_dir):
+        os.mkdir(salt_dir)
+    salt_link = os.path.join(salt_dir, 'klayout_ipc')
+
+    lyipc_config = os.path.realpath(os.path.join('..', '..', 'klayout_dot_config'))
+
+    if not is_windows():
+        os.symlink(lyipc_config, salt_link)  # so easy. Thanks UNIX
+    else:
+        try:
+            os.symlink(lyipc_config, salt_link)
+            return
+        except AttributeError:
+            pass
+        import subprocess
+        try:
+            retval = subprocess.call(['ln', '-s', lyipc_config, salt_link])
+            assert retval == 0
+            return
+        except (subprocess.CalledProcessError, WindowsError, AssertionError):
+            pass
+        try:
+            windows_symlink_override(lyipc_config, salt_link)
+            return
+        except WindowsError:
+            pass
+        raise WindowsError('Failed to find a way to link to a file in windows')
+
+
+def windows_symlink_override(source, link_name):
+    ''' Creates a symbolic link pointing to source named link_name.
+        From https://stackoverflow.com/questions/1447575/symlinks-on-windows
+    '''
+    import ctypes
+    csl = ctypes.windll.kernel32.CreateSymbolicLinkW
+    csl.argtypes = (ctypes.c_wchar_p, ctypes.c_wchar_p, ctypes.c_uint32)
+    csl.restype = ctypes.c_ubyte
+    flags = 0
+    if source is not None and os.path.isdir(source):
+        flags = 1
+    if csl(link_name, source, flags) == 0:
+        raise ctypes.WinError()
+
 
 def readme():
     with open('README.rst') as fx:
         return fx.read()
+
+
+class PostInstall(install):
+    def run(self):
+        install.run(self)
+        try:
+            link_to_salt()
+        except Exception as err:
+            print('Autoinstall into klayout salt failed with the following')
+            print(err)
+            print('\nYou must perform a manual install as described in the README.')
+
 
 setup(name='lyipc',
       version='0.1.4',
@@ -13,4 +92,5 @@ setup(name='lyipc',
       license='MIT',
       packages=['lyipc'],
       install_requires=[],
+      cmdclass={'install': PostInstall},
       )


### PR DESCRIPTION
## Changes
Autoinstall into klayout when the package is installed via pip.

You can do it in user mode with `pip install lyipc`. Then you're ready to go.

Or in developer mode, clone from git and install from the local clone with the `-e` flag